### PR TITLE
feat(repo): add clack for prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@ Workflows are sheduled to run automatically every Monday, Wednesday and Friday
 
 - clone this repo
 - run `pnpm i`
-- run `pnpm test` to run all suites
+- run `pnpm test all` to run all suites
 - or `pnpm test <suitename>` to select a suite
+- or just `pnpm test` to get prompts to select a suite
 - or `tsx ecosystem-ci.ts`
 
 The repositories are checked out into `workspace` subdirectory as shallow clones

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "lint:fix": "pnpm lint --fix",
     "format": "prettier --ignore-path .gitignore --check .",
     "format:fix": "pnpm format --write",
-    "test": "tsx ecosystem-ci.ts"
+    "test-ci": "tsx ecosystem-ci.ts",
+    "test": "node test.js"
   },
   "simple-git-hooks": {
     "pre-commit": "pnpm exec lint-staged --concurrent false"
@@ -38,9 +39,11 @@
   "homepage": "https://github.com/nrwl/nx-ecosystem-ci#readme",
   "dependencies": {
     "@actions/core": "^1.10.0",
+    "@clack/prompts": "^0.6.3",
     "cac": "^6.7.14",
     "execa": "^7.1.1",
-    "node-fetch": "^3.3.1"
+    "node-fetch": "^3.3.1",
+    "picocolors": "^1.0.0"
   },
   "devDependencies": {
     "@antfu/ni": "^0.21.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ dependencies:
   '@actions/core':
     specifier: ^1.10.0
     version: 1.10.0
+  '@clack/prompts':
+    specifier: ^0.6.3
+    version: 0.6.3
   cac:
     specifier: ^6.7.14
     version: 6.7.14
@@ -13,6 +16,9 @@ dependencies:
   node-fetch:
     specifier: ^3.3.1
     version: 3.3.1
+  picocolors:
+    specifier: ^1.0.0
+    version: 1.0.0
 
 devDependencies:
   '@antfu/ni':
@@ -1238,6 +1244,23 @@ packages:
       '@babel/helper-validator-identifier': 7.19.1
       to-fast-properties: 2.0.0
     dev: true
+
+  /@clack/core@0.3.2:
+    resolution: {integrity: sha512-FZnsNynwGDIDktx6PEZK1EuCkFpY4ldEX6VYvfl0dqeoLPb9Jpw1xoUXaVcGR8ExmYNm1w2vdGdJkEUYD/2pqg==}
+    dependencies:
+      picocolors: 1.0.0
+      sisteransi: 1.0.5
+    dev: false
+
+  /@clack/prompts@0.6.3:
+    resolution: {integrity: sha512-AM+kFmAHawpUQv2q9+mcB6jLKxXGjgu/r2EQjEwujgpCdzrST6BJqYw00GRn56/L/Izw5U7ImoLmy00X/r80Pw==}
+    dependencies:
+      '@clack/core': 0.3.2
+      picocolors: 1.0.0
+      sisteransi: 1.0.5
+    dev: false
+    bundledDependencies:
+      - is-unicode-supported
 
   /@esbuild-kit/cjs-loader@2.4.2:
     resolution: {integrity: sha512-BDXFbYOJzT/NBEtp71cvsrGPwGAMGRB/349rwKuoxNSiKjPraNNnlK6MIIabViCjqZugu6j+xeMDlEkWdHHJSg==}
@@ -2819,7 +2842,6 @@ packages:
 
   /picocolors@1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
-    dev: true
 
   /picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
@@ -2978,6 +3000,10 @@ packages:
     hasBin: true
     requiresBuild: true
     dev: true
+
+  /sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+    dev: false
 
   /slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}

--- a/test.js
+++ b/test.js
@@ -1,0 +1,56 @@
+import { intro, outro, select, isCancel, cancel, note } from '@clack/prompts'
+import { execSync } from 'node:child_process'
+import fs from 'node:fs'
+import color from 'picocolors'
+
+async function main() {
+	intro(color.inverse(' run your test suite '))
+
+	const testFolder = './tests/'
+	const arrayOfTestFiles = fs.readdirSync(testFolder)
+
+	const options = arrayOfTestFiles.map((file) => {
+		return {
+			value: file.replace('.ts', ''),
+			label: `Test ${color.bold(color.magenta(file.replace('.ts', '')))}`,
+		}
+	})
+
+	options.push({
+		value: 'all',
+		label: `Run ${color.bold(color.magenta('all'))} suites`,
+	})
+
+	let projectType = undefined
+	const userInputNameOfSuite = process.argv[2]
+
+	if (
+		userInputNameOfSuite === 'all' ||
+		arrayOfTestFiles.includes(`${userInputNameOfSuite}.ts`)
+	) {
+		projectType = userInputNameOfSuite
+		note(`Selected ${color.bold(color.magenta(projectType))}`)
+	} else {
+		projectType = await select({
+			message: 'Pick which test suite you want to run',
+			options: options,
+		})
+
+		if (isCancel(projectType)) {
+			cancel('Operation cancelled')
+			return process.exit(0)
+		}
+	}
+
+	projectType = projectType === 'all' ? '' : projectType
+
+	outro(
+		`Running ${color.bold(color.magenta('pnpm run test-ci ' + projectType))}`,
+	)
+
+	execSync(`pnpm run test-ci ${projectType}`, {
+		stdio: 'inherit',
+	})
+}
+
+main().catch(console.error)


### PR DESCRIPTION
<!-- Thank you for adding a new test suite for your project in the Nx Ecosystem CI -->

## What I did

Added `@clack/prompts` to create an interactive way of running the tests. Now when you run `pnpm test` it asks you which suite you want to run.


