### PR TITLE
fix: update monodon-rust file and add rust to the ci

### DIFF
--- a/.github/workflows/ecosystem-ci-selected.yml
+++ b/.github/workflows/ecosystem-ci-selected.yml
@@ -40,6 +40,7 @@ jobs:
         with:
           node-version: 18
         id: setup-node
+      - uses: dtolnay/rust-toolchain@stable
       - uses: denoland/setup-deno@v1
         with:
           deno-version: v1.x

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -42,6 +42,7 @@ jobs:
         with:
           node-version: 18
         id: setup-node
+      - uses: dtolnay/rust-toolchain@stable
       - uses: denoland/setup-deno@v1
         with:
           deno-version: v1.x

--- a/tests/monodon-rust.ts
+++ b/tests/monodon-rust.ts
@@ -6,7 +6,8 @@ export async function test(options: RunOptions) {
 		...options,
 		repo: 'Cammisuli/monodon',
 		branch: 'main',
-		build: ['build rust'],
-		test: ['test rust'],
+		build: ['build'],
+		test: ['test'],
+		e2e: ['e2e'],
 	})
 }


### PR DESCRIPTION
<!-- Thank you for adding a new test suite for your project in the Nx Ecosystem CI -->

## What I did
* Updated monodon-rust test file to run e2es and use the correct script names.
* also updated CI so that it has rust installed aswell so that the monodon run e2es pass here
## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (you ran `pnpm test <name-of-suite>` locally and it passes)
